### PR TITLE
feat: npmRebuildをtrueに設定し、Electronのバージョンを34.5.4に変更

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,7 +37,7 @@ linux:
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}
-npmRebuild: false
+npmRebuild: true
 publish:
   provider: generic
   url: https://example.com/auto-updates

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
-    "postinstall": "electron-builder install-app-deps",
+    "postinstall": "electron-builder install-app-deps && pnpm run rebuild",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",
@@ -25,7 +25,9 @@
     "web:preview": "vite preview -c vite.web.config.ts",
     "server:dev": "ts-node src/server/main.ts",
     "server:build": "tsc -p src/server/tsconfig.json",
-    "server:start": "node src/server/dist/main.js"
+    "server:start": "node src/server/dist/main.js",
+    "rebuild": "pnpm rebuild node-pty && cd src/server && pnpm rebuild node-pty && cd ../..",
+    "build:all": "pnpm run rebuild && electron-builder install-app-deps"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.1",
@@ -57,7 +59,7 @@
     "@types/ws": "^8.5.10",
     "@vitejs/plugin-react": "^4.3.4",
     "concurrently": "^8.2.2",
-    "electron": "^35.1.5",
+    "electron": "34.5.4",
     "electron-builder": "^25.1.8",
     "electron-vite": "^3.1.0",
     "eslint": "^9.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@electron-toolkit/preload':
         specifier: ^3.0.1
-        version: 3.0.2(electron@35.4.0)
+        version: 3.0.2(electron@34.5.4)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@35.4.0)
+        version: 4.0.0(electron@34.5.4)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.1.4)(react@19.1.0)
@@ -91,8 +91,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2
       electron:
-        specifier: ^35.1.5
-        version: 35.4.0
+        specifier: 34.5.4
+        version: 34.5.4
       electron-builder:
         specifier: ^25.1.8
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
@@ -895,9 +895,6 @@ packages:
   '@types/node@20.17.47':
     resolution: {integrity: sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ==}
 
-  '@types/node@22.15.18':
-    resolution: {integrity: sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==}
-
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -1572,8 +1569,8 @@ packages:
       '@swc/core':
         optional: true
 
-  electron@35.4.0:
-    resolution: {integrity: sha512-VIPSNcUnic00aaE83w6BW4Dj1kE8A5DU0nVbvwqotN3+gseGunbP4WyHp/kfKXVKQj1S3No3HnYxU5LJmYbAtw==}
+  electron@34.5.4:
+    resolution: {integrity: sha512-WXc3ElYW/1LH50CnpigSeRsK1AfFB/J8hCySFnhXDmz6BBAKhXlJ6bgw1k9ZldR5i+8JqX323773Jn8X3/Wagw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -3186,9 +3183,6 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -3534,17 +3528,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron-toolkit/preload@3.0.2(electron@35.4.0)':
+  '@electron-toolkit/preload@3.0.2(electron@34.5.4)':
     dependencies:
-      electron: 35.4.0
+      electron: 34.5.4
 
   '@electron-toolkit/tsconfig@1.0.1(@types/node@20.17.47)':
     dependencies:
       '@types/node': 20.17.47
 
-  '@electron-toolkit/utils@4.0.0(electron@35.4.0)':
+  '@electron-toolkit/utils@4.0.0(electron@34.5.4)':
     dependencies:
-      electron: 35.4.0
+      electron: 34.5.4
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -4148,10 +4142,6 @@ snapshots:
   '@types/node@20.17.47':
     dependencies:
       undici-types: 6.19.8
-
-  '@types/node@22.15.18':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -5014,10 +5004,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@35.4.0:
+  electron@34.5.4:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 22.15.18
+      '@types/node': 20.17.47
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6934,8 +6924,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.19.8: {}
-
-  undici-types@6.21.0: {}
 
   unique-filename@2.0.1:
     dependencies:


### PR DESCRIPTION
- electron-builder.yml: npmRebuildをfalseからtrueに変更
- package.json: postinstallスクリプトにpnpm run rebuildを追加し、Electronのバージョンを35.1.5から34.5.4に変更
- pnpm-lock.yaml: Electronのバージョンを35.4.0から34.5.4に変更